### PR TITLE
Untyped Plutarch validator

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
     "editor.formatOnSave": true,
-    "haskell.formattingProvider": "fourmolu"
+    "haskell.formattingProvider": "fourmolu",
+    "files.watcherExclude": {
+        "**/.direnv/**": true,
+        "**/dist-newstyle/**": true
+    }
 }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 Compare [Pluto](https://github.com/Plutonomicon/pluto) and [Plutarch](https://github.com/Plutonomicon/plutarch), via small examples and sample contracts, along the axis of developer ergonomics as well as generated script size.
 
+## Tasks 
+
+- [x] Untyped Plutarch validator
+- [ ] Plutarch: ScriptContext types
+- [ ] Typed Plutarch validator
+
 ## Developing
 
 If you are developing with VSCode, [`nix-direnv`](https://github.com/nix-community/nix-direnv) is recommended. Using home-manager, you can install it as follows:

--- a/cabal-haskell.nix.project
+++ b/cabal-haskell.nix.project
@@ -259,3 +259,8 @@ source-repository-package
   type: git
   location: https://github.com/Plutonomicon/pluto
   tag: 6546ff776ba811966af3a975938ada69c61f01ec
+
+source-repository-package
+  type: git
+  location: https://github.com/Plutonomicon/plutarch
+  tag: 9d08fcfc4b9cf260fd197cb7688a0a29b43d71cc

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,7 @@
               ps.Win32-network
               ps.word-array
               ps.pluto
+              ps.plutarch
             ];
           };
 
@@ -110,6 +111,7 @@
             "https://github.com/input-output-hk/Win32-network"."2d1a01c7cbb9f68a1aefe2934aad6c70644ebfea" = "sha256-uvYEWalN62ETpH45/O7lNHo4rAIaJtYpLWdIcAkq3dA=";
             "https://github.com/input-output-hk/goblins"."cde90a2b27f79187ca8310b6549331e59595e7ba" = "z9ut0y6umDIjJIRjz9KSvKgotuw06/S8QDwOtVdGiJ0=";
             "https://github.com/Plutonomicon/pluto"."6546ff776ba811966af3a975938ada69c61f01ec" = "sha256-J1AHljKWjlmNMz/VfPxZ13e/f5S5fmlUW0b9jTTugAY";
+            "https://github.com/Plutonomicon/plutarch"."9d08fcfc4b9cf260fd197cb7688a0a29b43d71cc" = "sha256-8CPy3nxGpTq+D8ESDa8LT/3JemIvy7dLm9GsIWWIPa0=";
           };
         };
     in

--- a/plut.cabal
+++ b/plut.cabal
@@ -32,6 +32,7 @@ executable plut
   other-modules:
     Plut.Sample.Offchain
     Plut.Sample.Validator.Haskell
+    Plut.Sample.Validator.Plutarch
     Plut.Sample.Validator.Pluto
 
   build-depends:
@@ -43,6 +44,7 @@ executable plut
     , hedgehog
     , lens
     , mtl
+    , plutarch
     , pluto
     , plutus-contract
     , plutus-core

--- a/plut.cabal
+++ b/plut.cabal
@@ -39,6 +39,7 @@ executable plut
     , base
     , bytestring
     , containers
+    , fin
     , freer-extras
     , hashable
     , hedgehog

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -16,6 +16,7 @@ import Ledger hiding (singleton)
 import Ledger.Ada as Ada (lovelaceValueOf)
 import Plut.Sample.Offchain
 import Plut.Sample.Validator.Haskell (haskellValidator)
+import Plut.Sample.Validator.Plutarch (plutarchValidator)
 import Plut.Sample.Validator.Pluto (plutoValidator)
 import Plutus.Contract.Test (w1, w2, w3)
 import Plutus.Contract.Test qualified as PCT
@@ -134,10 +135,15 @@ smokeTrace validator = do
 
 tests :: IO ()
 tests = do
+  let validators =
+        [ ("Haskell", haskellValidator)
+        , ("Pluto", plutoValidator)
+        , ("Plutarch", plutarchValidator)
+        ]
   T.defaultMain $
     T.localOption (H.HedgehogTestLimit (Just 10)) . T.localOption (H.HedgehogShrinkLimit (Just 2)) $
       T.testGroup "Sample Contract" $
-        flip fmap [("Haskell", haskellValidator), ("Pluto", plutoValidator)] $ \(k, validator) ->
+        flip fmap validators $ \(k, validator) ->
           T.testGroup
             ("Validator:" <> k)
             [ QC.testProperty "contract" (modelCheck validator)
@@ -146,5 +152,5 @@ tests = do
 
 main :: IO ()
 main = do
-  Em.runEmulatorTraceIO $ smokeTrace plutoValidator
+  Em.runEmulatorTraceIO $ smokeTrace plutarchValidator
   tests

--- a/src/Plut/Sample/Validator/Plutarch.hs
+++ b/src/Plut/Sample/Validator/Plutarch.hs
@@ -1,14 +1,17 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE PostfixOperators #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Plut.Sample.Validator.Plutarch (plutarchValidator) where
 
+import Data.Kind (Type)
 import Data.Nat (Nat (S, Z), nat0, nat1, nat2)
 import Data.Text (Text)
 import Ledger.Scripts (Validator (..))
@@ -24,7 +27,9 @@ plutarchValidator :: Validator
 plutarchValidator =
   Validator $ compile validator
 
--- | TODO: Rewrite raw 'Untyped Plutarch' to use the types from typed eDSL
+{- | TODO: Rewrite raw 'Untyped Plutarch' to use the types from typed eDSL
+ Upstream the types to Plutarch
+-}
 validator :: forall s. Term s (PByteString :--> PByteString :--> PByteString :--> PUnit)
 validator =
   plam $ \datum (_redeemer :: Term s PByteString) (ctx :: Term s PByteString) ->
@@ -32,13 +37,15 @@ validator =
       (pTrace "yoyo:atProduct" $ atProduct 0 $ pTrace "yoyo:ctx" ctx)
       $ \txInfo ->
         plet (atProduct 7 $ pTrace "yoyo:txInfo" txInfo) $ \signatories' ->
-          plet (pUnListData £ punsafeCoerce (pTrace "yoyo:sig" signatories')) $ \signatories ->
+          plet ((PLC.UnListData #) £ punsafeCoerce (pTrace "yoyo:sig" signatories')) $ \signatories ->
             plet (pTrace "yoyo:hasElem" $ hasElem (punsafeCoerce datum) signatories) $ \(isBeneficiary :: Term s PBool) ->
               pif isBeneficiary (pcon PUnit) $ pTrace "yoyo:not-beneficiary" perror
 
 instance PEq POpaque where
   a £== b =
-    pBuiltin PLC.EqualsData nat0 £ a £ b
+    pBuiltin PLC.EqualsData £ a £ b
+
+-- List functions
 
 hasElem :: forall s. Term s POpaque -> Term s POpaque -> Term s PBool
 hasElem k list' =
@@ -58,7 +65,7 @@ hasElem k list' =
 
 atProduct :: Term s PInteger -> Term s a -> Term s POpaque
 atProduct n dat =
-  plet (pTrace "yoyo:pUnConstrData" $ pUnConstrData £ punsafeCoerce dat) $ \dat' ->
+  plet (pTrace "yoyo:pUnConstrData" $ (PLC.UnConstrData #) £ punsafeCoerce dat) $ \dat' ->
     pmatch' (pTrace "yoyo:dat'" dat') $ \(PPair _ products :: PPair s) ->
       atIndex n products
 
@@ -79,44 +86,18 @@ atIndex n =
                 x
                 (self £ (n' - 1) £ xs)
 
--- Returns a pair of Integer and [Data]
-pUnConstrData :: Term s (POpaque :--> POpaque)
-pUnConstrData = pBuiltin PLC.UnConstrData nat0
-
-pUnListData :: Term s (POpaque :--> POpaque)
-pUnListData = pBuiltin PLC.UnListData nat0
-
-pBuiltin :: PLC.DefaultFun -> Nat -> Term s a
-pBuiltin builtin forceLevel =
-  phoistAcyclic $ forceN forceLevel $ punsafeBuiltin builtin
-  where
-    forceN :: Nat -> Term s a -> Term s a
-    forceN Z = id
-    forceN (S n) = pforce . punsafeCoerce . forceN n
-
 -- All of these are working with `Data`
 
--- This is all opaque now, but we want to make it typed.
 data PPair s = PPair (Term s POpaque) (Term s POpaque)
 
 instance PlutusType PPair where
   type PInner PPair _ = POpaque
-  pcon' (PPair a b) = pMkPairData £ a £ b
+  pcon' (PPair a b) = (PLC.MkPairData #) £ a £ b -- There is no MkPair, plutus build constructs pair of data
   pmatch' pair f =
     -- TODO: use delay/force to avoid evaluating `pair` twice?
-    plet (pFstPair £ pair) $ \a ->
-      plet (pSndPair £ pair) $ \b ->
+    plet ((PLC.FstPair #) £ pair) $ \a ->
+      plet ((PLC.SndPair #) £ pair) $ \b ->
         f $ PPair a b
-
-pMkPairData :: Term s (POpaque :--> POpaque :--> POpaque)
-pMkPairData =
-  pBuiltin PLC.MkPairData nat0
-
-pFstPair :: Term s (POpaque :--> POpaque)
-pFstPair = pBuiltin PLC.FstPair nat2
-
-pSndPair :: Term s (POpaque :--> POpaque)
-pSndPair = pBuiltin PLC.SndPair nat2
 
 data PList s
   = PNil
@@ -125,30 +106,52 @@ data PList s
 instance PlutusType PList where
   type PInner PList _ = POpaque
   pcon' PNil = undefined -- TODO??
-  pcon' (PCons x xs) = pMkCons £ x £ xs
+  pcon' (PCons x xs) = (PLC.MkCons #) £ x £ xs
   pmatch' list f =
-    plet (pNullList £ list) $ \isEmpty ->
+    plet ((PLC.NullList #) £ list) $ \isEmpty ->
       pif
         (punsafeCoerce isEmpty)
         (f PNil)
         $ plet
-          (pHeadList £ list)
+          ((PLC.HeadList #) £ list)
           ( \head ->
-              plet (pTailList £ list) $ \tail ->
+              plet ((PLC.TailList #) £ list) $ \tail ->
                 f $ PCons head tail
           )
 
-pMkCons :: Term s (POpaque :--> POpaque :--> POpaque)
-pMkCons = pBuiltin PLC.MkCons nat1
-
-pNullList :: Term s (POpaque :--> PBool)
-pNullList = pBuiltin PLC.NullList nat1
-
-pHeadList :: Term s (POpaque :--> POpaque)
-pHeadList = pBuiltin PLC.HeadList nat1
-
-pTailList :: Term s (POpaque :--> POpaque)
-pTailList = pBuiltin PLC.TailList nat1
+-- Trace
 
 pTrace :: forall a s. Text -> Term s a -> Term s a
-pTrace s f = pBuiltin PLC.Trace nat1 £ pfromText s £ f
+pTrace s f = pBuiltin PLC.Trace £ pfromText s £ f
+
+-- Builtins
+
+(#) :: forall k (s :: k) (a :: k -> Type). PLC.DefaultFun -> Term s a
+(#) = pBuiltin
+infixl 6 #
+
+pBuiltin :: PLC.DefaultFun -> Term s a
+pBuiltin builtin =
+  phoistAcyclic $ forceN (forceLevel builtin) $ punsafeBuiltin builtin
+  where
+    forceN :: Nat -> Term s a -> Term s a
+    forceN Z = id
+    forceN (S n) = pforce . punsafeCoerce . forceN n
+
+class ForceLevel a where
+  forceLevel :: a -> Nat
+
+instance ForceLevel PLC.DefaultFun where
+  forceLevel = \case
+    PLC.EqualsData -> nat0
+    PLC.UnConstrData -> nat0
+    PLC.UnListData -> nat0
+    PLC.MkPairData -> nat0
+    PLC.FstPair -> nat2
+    PLC.SndPair -> nat2
+    PLC.MkCons -> nat1
+    PLC.NullList -> nat1
+    PLC.HeadList -> nat1
+    PLC.TailList -> nat1
+    PLC.Trace -> nat1
+    _ -> undefined

--- a/src/Plut/Sample/Validator/Plutarch.hs
+++ b/src/Plut/Sample/Validator/Plutarch.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Plut.Sample.Validator.Plutarch (plutarchValidator) where
+
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8)
+import Ledger.Scripts (Validator (..))
+import Plutarch
+import Plutarch.Bool
+import Plutarch.ByteString
+import Plutarch.Integer
+import Plutarch.Unit
+import PlutusCore qualified as PLC
+
+-- TODO: implement this
+plutarchValidator :: Validator
+plutarchValidator =
+  Validator $ compile validator
+
+validator :: forall s. Term s (PByteString :--> PByteString :--> PByteString :--> PUnit)
+validator =
+  plam $ \datum (_redeemer :: Term s PByteString) (ctx :: Term s PByteString) ->
+    pTrace "yoyo" $
+      plet
+        (atProduct 0 ctx)
+        $ \txInfo ->
+          plet (atProduct 7 txInfo) $ \signatories' ->
+            plet (pUnListData £ punsafeCoerce signatories') $ \signatories ->
+              plet (hasElem (punsafeCoerce datum) signatories) $ \(isBeneficiary :: Term s PBool) ->
+                pif isBeneficiary (pcon PUnit) perror
+
+instance PEq POpaque where
+  a £== b =
+    pBuiltin PLC.EqualsData £ a £ b
+
+hasElem :: forall s. Term s POpaque -> Term s POpaque -> Term s PBool
+hasElem k list' =
+  go £ list'
+  where
+    -- TODO: why can't i use phoistAcyclic  here?
+    go :: Term s (POpaque :--> PBool)
+    go =
+      pfix £$ plam $ \self list ->
+        pmatch' list $ \case
+          PNil -> pcon PFalse
+          PCons x xs ->
+            pif
+              (k £== x)
+              (pcon PTrue)
+              (self £ xs)
+
+atProduct :: Term s PInteger -> Term s a -> Term s POpaque
+atProduct n dat =
+  plet (pUnConstrData £ punsafeCoerce dat) $ \dat' ->
+    pmatch' dat' $ \(PPair _ products :: PPair s) ->
+      atIndex n products
+
+atIndex :: Term s PInteger -> Term s POpaque -> Term s POpaque
+atIndex n =
+  (go £ (n - 1) £)
+  where
+    go :: Term s (PInteger :--> POpaque :--> POpaque)
+    go = phoistAcyclic $
+      pfix
+        £$ plam
+        $ \self n' list ->
+          pmatch' list $ \case
+            PNil -> perror
+            PCons x xs ->
+              pifB (n' £== 0)
+                £ x
+                £ (self £ (n' - 1) £ xs)
+
+-- | Builtin IfThenElse (strict, not lazy like pmatch)
+pifB :: Term s PBool -> Term s (a :--> a :--> a)
+pifB = (pif' £)
+
+-- Returns a pair of Integer and [Data]
+pUnConstrData :: Term s (POpaque :--> POpaque)
+pUnConstrData = pBuiltin PLC.UnConstrData
+
+pUnListData :: Term s (POpaque :--> POpaque)
+pUnListData = pBuiltin PLC.UnListData
+
+pBuiltin :: PLC.DefaultFun -> Term s a
+pBuiltin builtin =
+  phoistAcyclic $ pforce $ punsafeBuiltin builtin
+
+-- All of these are working with `Data`
+
+-- This is all opaque now, but we want to make it typed.
+data PPair s = PPair (Term s POpaque) (Term s POpaque)
+
+instance PlutusType PPair where
+  type PInner PPair _ = POpaque
+  pcon' (PPair a b) = pMkPairData £ a £ b
+  pmatch' pair f =
+    plet (pFstPair £ pair) $ \a ->
+      plet (pSndPair £ pair) $ \b ->
+        f $ PPair a b
+
+pMkPairData :: Term s (POpaque :--> POpaque :--> POpaque)
+pMkPairData =
+  pBuiltin PLC.MkPairData
+
+pFstPair :: Term s (POpaque :--> POpaque)
+pFstPair = pBuiltin PLC.FstPair
+
+pSndPair :: Term s (POpaque :--> POpaque)
+pSndPair = pBuiltin PLC.SndPair
+
+data PList s
+  = PNil
+  | PCons (Term s POpaque) (Term s POpaque)
+
+instance PlutusType PList where
+  type PInner PList _ = POpaque
+  pcon' PNil = undefined -- TODO??
+  pcon' (PCons x xs) = pMkCons £ x £ xs
+  pmatch' list f =
+    plet (pChooseList £ list £ punsafeCoerce (pcon' PTrue) £ punsafeCoerce (pcon' PTrue)) $ \isEmpty ->
+      pifB (punsafeCoerce isEmpty)
+        £ f PNil
+        £ plet
+          (pHeadList £ list)
+          ( \head ->
+              plet (pTailList £ list) $ \tail ->
+                f $ PCons head tail
+          )
+
+pMkCons :: Term s (POpaque :--> POpaque :--> POpaque)
+pMkCons = pBuiltin PLC.MkCons
+
+pHeadList :: Term s (POpaque :--> POpaque)
+pHeadList = pBuiltin PLC.HeadList
+
+pTailList :: Term s (POpaque :--> POpaque)
+pTailList = pBuiltin PLC.TailList
+
+pChooseList :: Term s (POpaque :--> POpaque :--> POpaque :--> POpaque)
+pChooseList = pBuiltin PLC.ChooseList
+
+pTrace :: forall a s. Text -> Term s a -> Term s a
+pTrace s f = pBuiltin PLC.Trace £ pByteString (encodeUtf8 s) £ f
+
+pByteString :: ByteString -> Term s PByteString
+pByteString =
+  punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniByteString

--- a/src/Plut/Sample/Validator/Plutarch.hs
+++ b/src/Plut/Sample/Validator/Plutarch.hs
@@ -34,12 +34,12 @@ validator :: forall s. Term s (PByteString :--> PByteString :--> PByteString :--
 validator =
   plam $ \datum (_redeemer :: Term s PByteString) (ctx :: Term s PByteString) ->
     plet
-      (pTrace "yoyo:atProduct" $ atProduct 0 $ pTrace "yoyo:ctx" ctx)
+      (pTrace "plu:atProduct" $ atProduct 0 $ pTrace "plu:ctx" ctx)
       $ \txInfo ->
-        plet (atProduct 7 $ pTrace "yoyo:txInfo" txInfo) $ \signatories' ->
-          plet ((PLC.UnListData #) £ punsafeCoerce (pTrace "yoyo:sig" signatories')) $ \signatories ->
-            plet (pTrace "yoyo:hasElem" $ hasElem (punsafeCoerce datum) signatories) $ \(isBeneficiary :: Term s PBool) ->
-              pif isBeneficiary (pcon PUnit) $ pTrace "yoyo:not-beneficiary" perror
+        plet (atProduct 7 $ pTrace "plu:txInfo" txInfo) $ \signatories' ->
+          plet ((PLC.UnListData #) £ punsafeCoerce (pTrace "plu:sig" signatories')) $ \signatories ->
+            plet (pTrace "plu:hasElem" $ hasElem (punsafeCoerce datum) signatories) $ \(isBeneficiary :: Term s PBool) ->
+              pif isBeneficiary (pcon PUnit) $ pTrace "plu:not-beneficiary" perror
 
 instance PEq POpaque where
   a £== b =
@@ -56,7 +56,7 @@ hasElem k list' =
     go =
       pfix £$ plam $ \self list ->
         pmatch' list $ \case
-          PNil -> pTrace "yoyo:hasElem:error" $ pcon PFalse
+          PNil -> pTrace "plu:hasElem:error" $ pcon PFalse
           PCons x xs ->
             pif
               (k £== x)
@@ -65,8 +65,8 @@ hasElem k list' =
 
 atProduct :: Term s PInteger -> Term s a -> Term s POpaque
 atProduct n dat =
-  plet (pTrace "yoyo:pUnConstrData" $ (PLC.UnConstrData #) £ punsafeCoerce dat) $ \dat' ->
-    pmatch' (pTrace "yoyo:dat'" dat') $ \(PPair _ products :: PPair s) ->
+  plet (pTrace "plu:pUnConstrData" $ (PLC.UnConstrData #) £ punsafeCoerce dat) $ \dat' ->
+    pmatch' (pTrace "plu:dat'" dat') $ \(PPair _ products :: PPair s) ->
       atIndex n products
 
 atIndex :: Term s PInteger -> Term s POpaque -> Term s POpaque
@@ -78,8 +78,8 @@ atIndex n =
       pfix
         £$ plam
         $ \self n' list ->
-          pmatch' (pTrace "yoyo:n" list) $ \case
-            PNil -> pTrace "yoyo:atIndex:err" perror
+          pmatch' (pTrace "plu:n" list) $ \case
+            PNil -> pTrace "plu:atIndex:err" perror
             PCons x xs ->
               pif
                 (n' £== 0)

--- a/src/Plut/Sample/Validator/Pluto.hs
+++ b/src/Plut/Sample/Validator/Pluto.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Plut.Sample.Validator.Pluto (plutoValidator) where
@@ -8,6 +7,8 @@ import PlutusCore.Assembler.Assemble qualified as Pluto
 import PlutusCore.Assembler.FFI qualified as PlutoFFI
 import PlutusCore.Assembler.Types.AST qualified as Pluto
 
+-- FIXME: This is known to trigger a HLS bug with symbol resolution
+-- See https://github.com/haskell/haskell-language-server/issues/1737#issuecomment-825516365
 plutoValidatorProg :: Pluto.Program ()
 plutoValidatorProg = $(PlutoFFI.load "src/Plut/Sample/Validator/validator.pluto")
 


### PR DESCRIPTION
This is a direct translation of the Pluto validator. As a next step, upstream some of these and (gradually) rewrite the untyped code to use Haskell types (all the way to ScriptContext types)