### PR TITLE
Add ScriptContext data using PData

### DIFF
--- a/cabal-haskell.nix.project
+++ b/cabal-haskell.nix.project
@@ -263,4 +263,4 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/srid/plutarch
-  tag: fa0aaf898079aba436603714c05f34e7d2276542
+  tag: 8eff2004e22b62d0dcae6fd64a18dc2e74f434d0

--- a/cabal-haskell.nix.project
+++ b/cabal-haskell.nix.project
@@ -262,5 +262,5 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/Plutonomicon/plutarch
-  tag: 9d08fcfc4b9cf260fd197cb7688a0a29b43d71cc
+  location: https://github.com/srid/plutarch
+  tag: fa0aaf898079aba436603714c05f34e7d2276542

--- a/flake.nix
+++ b/flake.nix
@@ -111,7 +111,8 @@
             "https://github.com/input-output-hk/Win32-network"."2d1a01c7cbb9f68a1aefe2934aad6c70644ebfea" = "sha256-uvYEWalN62ETpH45/O7lNHo4rAIaJtYpLWdIcAkq3dA=";
             "https://github.com/input-output-hk/goblins"."cde90a2b27f79187ca8310b6549331e59595e7ba" = "z9ut0y6umDIjJIRjz9KSvKgotuw06/S8QDwOtVdGiJ0=";
             "https://github.com/Plutonomicon/pluto"."6546ff776ba811966af3a975938ada69c61f01ec" = "sha256-J1AHljKWjlmNMz/VfPxZ13e/f5S5fmlUW0b9jTTugAY";
-            "https://github.com/srid/plutarch"."fa0aaf898079aba436603714c05f34e7d2276542" = "sha256-5MTJeLmOtMysQ9nvq730xKpXnlTVaVpN4u9ypbFdKjI=";
+            "https://github.com/srid/plutarch"."8eff2004e22b62d0dcae6fd64a18dc2e74f434d0" =
+              "sha256-m2/Mq9eLcaMO7b/6OTatGHnVaF27Mli3zNrE1JAE8V0=";
           };
         };
     in

--- a/flake.nix
+++ b/flake.nix
@@ -111,7 +111,7 @@
             "https://github.com/input-output-hk/Win32-network"."2d1a01c7cbb9f68a1aefe2934aad6c70644ebfea" = "sha256-uvYEWalN62ETpH45/O7lNHo4rAIaJtYpLWdIcAkq3dA=";
             "https://github.com/input-output-hk/goblins"."cde90a2b27f79187ca8310b6549331e59595e7ba" = "z9ut0y6umDIjJIRjz9KSvKgotuw06/S8QDwOtVdGiJ0=";
             "https://github.com/Plutonomicon/pluto"."6546ff776ba811966af3a975938ada69c61f01ec" = "sha256-J1AHljKWjlmNMz/VfPxZ13e/f5S5fmlUW0b9jTTugAY";
-            "https://github.com/Plutonomicon/plutarch"."9d08fcfc4b9cf260fd197cb7688a0a29b43d71cc" = "sha256-8CPy3nxGpTq+D8ESDa8LT/3JemIvy7dLm9GsIWWIPa0=";
+            "https://github.com/srid/plutarch"."fa0aaf898079aba436603714c05f34e7d2276542" = "sha256-5MTJeLmOtMysQ9nvq730xKpXnlTVaVpN4u9ypbFdKjI=";
           };
         };
     in

--- a/src/Plut/Sample/Validator/Plutarch.hs
+++ b/src/Plut/Sample/Validator/Plutarch.hs
@@ -12,18 +12,15 @@
 
 module Plut.Sample.Validator.Plutarch (plutarchValidator) where
 
-import Data.Kind (Type)
-import Data.Proxy (Proxy (..))
-import Data.Text (Text)
-import Data.Type.Nat
 import Ledger.Scripts (Validator (..))
 import Plutarch
 import Plutarch.Bool
+import Plutarch.Builtin
+import Plutarch.Builtin.List qualified as BL
+import Plutarch.Builtin.Pair qualified as BP
 import Plutarch.ByteString
 import Plutarch.Integer
-import Plutarch.String (PString, pfromText)
 import Plutarch.Unit
-import PlutusCore qualified as PLC
 
 plutarchValidator :: Validator
 plutarchValidator =
@@ -39,7 +36,7 @@ validator =
     pmatch' ctxT $ \(ctx :: ScriptContext s) ->
       pmatch' (scriptContextTxInfo ctx) $ \(txInfo :: TxInfo s) ->
         plet (txInfoSignatories txInfo) $ \signatories ->
-          plet (hasElem £ punsafeCoerce datum £ signatories) $ \(isBeneficiary :: Term s PBool) ->
+          plet (BL.contains £ signatories £ punsafeCoerce datum) $ \(isBeneficiary :: Term s PBool) ->
             pif isBeneficiary (pcon PUnit) $ "plu:not-beneficiary" !£ perror
 
 data ScriptContext s = ScriptContext
@@ -61,7 +58,7 @@ instance PlutusType ScriptContext where
   pcon' (ScriptContext a b) =
     (PLC.ConstrData #)
       -- Only sum type, indexed at 0
-      £ (pcon' $ PPairData
+      £ (pcon' $ PPair
             (punsafeCoerce $ (PLC.IData #) £ (0 :: Term s PInteger))
             (punsafeCoerce $ (PLC.MkNilData #) £ pcon PUnit))
       -- Fields of the first sum choice
@@ -74,10 +71,10 @@ instance PlutusType ScriptContext where
   pcon' = undefined
   pmatch' dat f =
     plet ("plu:pUnConstrData" !£ (UnConstrData #£ punsafeCoerce dat)) $ \dat' ->
-      pmatch' ("plu:dat'" !£ dat') $ \(PPairData _n0 products :: PPairData PInteger (PList POpaque) s) ->
-        plet (atIndex £ (0 :: Term s PInteger) £ products) $ \a ->
+      BP.matchPair ("plu:dat'" !£ dat') $ \(PPair _n0 products :: PPair PInteger (PList POpaque) s) ->
+        plet (BL.atIndex £ (0 :: Term s PInteger) £ products) $ \a ->
           -- TODO: Allow lazy retrieval of fields
-          plet (atIndex £ (1 :: Term s PInteger) £ products) $ \b ->
+          plet (BL.atIndex £ (1 :: Term s PInteger) £ products) $ \b ->
             f (ScriptContext (punsafeCoerce a) b)
 
 instance PlutusType TxInfo where
@@ -85,164 +82,12 @@ instance PlutusType TxInfo where
   pcon' = undefined
   pmatch' dat f =
     plet ("plu:pUnConstrData" !£ UnConstrData #£ punsafeCoerce dat) $ \dat' ->
-      pmatch' ("plu:dat'" !£ dat') $ \(PPairData _ products :: PPairData PInteger (PList POpaque) s) ->
+      BP.matchPair ("plu:dat'" !£ dat') $ \(PPair _ products :: PPair PInteger (PList POpaque) s) ->
         -- TODO: hardcoding index
-        plet (atIndex £ (7 :: Term s PInteger) £ products) $ \x ->
+        plet (BL.atIndex £ (7 :: Term s PInteger) £ products) $ \x ->
           f (TxInfo $ UnListData #£ punsafeCoerce x)
 
--------------------------------
--- To upstream (after clean up)
--------------------------------
+-- TODO: Drop this after switching to PData from Plutarch
 instance PEq POpaque where
   a £== b =
     EqualsData #£ a £ b
-
--- Pair of Data
-
-data PPairData a b s = PPairData (Term s a) (Term s b)
-
-instance PlutusType (PPairData a b) where
-  type PInner (PPairData a b) _ = PPairData a b
-  pcon' (PPairData a b) = MkPairData #£ a £ b -- There is no MkPair
-  pmatch' pair f =
-    -- TODO: use delay/force to avoid evaluating `pair` twice?
-    plet (FstPair #£ pair) $ \a ->
-      plet (SndPair #£ pair) $ \b ->
-        f $ PPairData a b
-
--- List
-
--- TODO: Rename to PListData?
-data PList a s
-  = PNil
-  | PCons (Term s a) (Term s (PList a))
-
-instance PlutusType (PList a) where
-  type PInner (PList a) _ = PList a
-  pcon' PNil = undefined -- TODO
-  pcon' (PCons x xs) = MkCons #£ x £ xs
-  pmatch' list f =
-    plet (NullList #£ list) $ \isEmpty ->
-      pif
-        (punsafeCoerce isEmpty)
-        (f PNil)
-        $ plet
-          (HeadList #£ list)
-          ( \head ->
-              plet (TailList #£ list) $ \tail ->
-                f $ PCons head tail
-          )
-
-hasElem :: PEq a => ClosedTerm (a :--> PList a :--> PBool)
-hasElem =
-  pfix £$ plam $ \self k list ->
-    pmatch' list $ \case
-      PNil ->
-        "plu:hasElem:fail"
-          !£ pcon PFalse
-      PCons x xs ->
-        pif
-          (k £== x)
-          (pcon PTrue)
-          (self £ k £ xs)
-
-atIndex :: ClosedTerm (PInteger :--> PList a :--> a)
-atIndex =
-  pfix £$ plam $ \self n' list ->
-    pmatch' ("plu:n" !£ list) $ \case
-      PNil ->
-        "plu:atIndex:err"
-          !£ perror
-      PCons x xs ->
-        pif
-          (n' £== 0)
-          x
-          (self £ (n' - 1) £ xs)
-
--- Builtins
-
-{- | Type spec for PLC's untyped builtin
-
- The `forces` value determines the repeated application of `FORCE` when
- evaluating the builtin function.
-
- Example: UnConstrData #£ someData
--}
-data PBuiltin (forces :: Nat) (args :: [k -> Type]) (res :: k -> Type) where
-  UnConstrData :: PBuiltin Nat0 '[POpaque] (PPairData PInteger (PList POpaque))
-  UnListData :: PBuiltin Nat0 '[POpaque] (PList POpaque)
-  MkPairData :: PBuiltin Nat0 '[a, b] (PPairData a b)
-  FstPair :: PBuiltin Nat2 '[PPairData a b] a
-  SndPair :: PBuiltin Nat2 '[PPairData a b] b
-  MkCons :: PBuiltin Nat1 '[a, PList a] (PList a)
-  NullList :: PBuiltin Nat1 '[a] PBool
-  HeadList :: PBuiltin Nat1 '[PList a] a
-  TailList :: PBuiltin Nat1 '[PList a] (PList a)
-  EqualsData :: PBuiltin Nat0 '[POpaque, POpaque] PBool
-  Trace :: PBuiltin Nat1 '[PString, a] a
-
-type family PBuiltinType (args :: [k -> Type]) (res :: k -> Type) where
-  PBuiltinType '[] res = res
-  PBuiltinType (a ': as) res = a :--> PBuiltinType as res
-
-pBuiltinTerm ::
-  forall args res forces s.
-  PBuiltin forces args res ->
-  Term s (PBuiltinType args res)
-pBuiltinTerm b =
-  phoistAcyclic $ case b of
-    UnConstrData ->
-      force @forces Proxy . punsafeBuiltin $ PLC.UnConstrData
-    UnListData ->
-      force @forces Proxy . punsafeBuiltin $ PLC.UnListData
-    MkPairData ->
-      force @forces Proxy . punsafeBuiltin $ PLC.MkPairData
-    FstPair ->
-      force @forces Proxy . punsafeBuiltin $ PLC.FstPair
-    SndPair ->
-      force @forces Proxy . punsafeBuiltin $ PLC.SndPair
-    MkCons ->
-      force @forces Proxy . punsafeBuiltin $ PLC.MkCons
-    NullList ->
-      force @forces Proxy . punsafeBuiltin $ PLC.NullList
-    HeadList ->
-      force @forces Proxy . punsafeBuiltin $ PLC.HeadList
-    TailList ->
-      force @forces Proxy . punsafeBuiltin $ PLC.TailList
-    EqualsData ->
-      force @forces Proxy . punsafeBuiltin $ PLC.EqualsData
-    Trace ->
-      force @forces Proxy . punsafeBuiltin $ PLC.Trace
-  where
-    force :: forall forces s a. SNatI forces => Proxy (forces :: Nat) -> Term s a -> Term s a
-    force Proxy =
-      let sn = snat :: SNat forces
-       in forceN (snatToNat sn)
-    forceN :: forall s a. Nat -> Term s a -> Term s a
-    forceN Z = id
-    forceN (S n) = pforce . punsafeCoerce . forceN n
-
-(#£) ::
-  forall
-    k
-    (args :: [k -> Type])
-    (res :: k -> Type)
-    (a :: k -> Type)
-    (b :: k -> Type)
-    (forces :: Nat)
-    (s :: k).
-  (PBuiltinType args res ~ (a :--> b)) =>
-  PBuiltin forces args res ->
-  Term s a ->
-  Term s b
-(#£) b = (pBuiltinTerm b £)
-infixl 9 #£
-
--- Handy builtin aliases
-
-pTrace :: Text -> Term s a -> Term s a
-pTrace s f = Trace #£ pfromText s £ f
-
-(!£) :: forall k (s :: k) (a :: k -> Type). Text -> Term s a -> Term s a
-(!£) = pTrace
-infixl 8 !£


### PR DESCRIPTION
This PR adds a type-safe version of using PLC's builtins as well as a prototypical version (albeit manually done for a specific type, ScriptContext/TxInfo, to begin with) of what would be a generic sum/product type representation in Plutarch.

- [x] Upstream the Builtins to Plutarch https://github.com/Plutonomicon/plutarch/pull/23
  - [x] Integrate/merge with upstream's `PBuiltinList` and `PBuiltinPair` accordingly
- [x] Evaluate use of `PData` in place of `POpaque`